### PR TITLE
fix setuptool version error

### DIFF
--- a/googletrans/__init__.py
+++ b/googletrans/__init__.py
@@ -1,6 +1,6 @@
 """Free Google Translate API for Python. Translates totally free of charge."""
 __all__ = 'Translator',
-__version__ = '3.1.0-moded'
+__version__ = '3.1.1'
 
 
 from googletrans.client import Translator


### PR DESCRIPTION
After setuptool 66.0, versions must conform PEP440.
https://github.com/pypa/setuptools/issues/3772
https://peps.python.org/pep-0440/